### PR TITLE
feat: 게시글,답글,인용,리포스트,좋아요,조회수 서비스 구현

### DIFF
--- a/src/main/java/sns/SnsApplication.java
+++ b/src/main/java/sns/SnsApplication.java
@@ -3,9 +3,11 @@ package sns;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableJpaAuditing
+@EnableScheduling
 public class SnsApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/sns/config/GlobalExceptionHandler.java
+++ b/src/main/java/sns/config/GlobalExceptionHandler.java
@@ -7,6 +7,10 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import sns.domain.follow.FollowException;
+import sns.domain.post.PostException;
+import sns.domain.quote.QuoteException;
+import sns.domain.reply.ReplyException;
+import sns.domain.repost.RepostException;
 import sns.domain.user.UserException;
 
 @RestControllerAdvice
@@ -21,6 +25,34 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(FollowException.class)
     public ResponseEntity<ErrorResponse> handleFollowException(FollowException e) {
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(new ErrorResponse(e.getMessage()));
+    }
+
+    @ExceptionHandler(PostException.class)
+    public ResponseEntity<ErrorResponse> handlePostException(PostException e) {
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(new ErrorResponse(e.getMessage()));
+    }
+
+    @ExceptionHandler(ReplyException.class)
+    public ResponseEntity<ErrorResponse> handleReplyException(ReplyException e) {
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(new ErrorResponse(e.getMessage()));
+    }
+
+    @ExceptionHandler(QuoteException.class)
+    public ResponseEntity<ErrorResponse> handleQuoteException(QuoteException e) {
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(new ErrorResponse(e.getMessage()));
+    }
+
+    @ExceptionHandler(RepostException.class)
+    public ResponseEntity<ErrorResponse> handleRepostException(RepostException e) {
         return ResponseEntity
                 .status(HttpStatus.BAD_REQUEST)
                 .body(new ErrorResponse(e.getMessage()));

--- a/src/main/java/sns/controller/PostController.java
+++ b/src/main/java/sns/controller/PostController.java
@@ -1,0 +1,82 @@
+package sns.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+import sns.config.AuthUser;
+import sns.controller.dto.PostCreateRequest;
+import sns.controller.dto.PostResponse;
+import sns.controller.dto.PostUpdateRequest;
+import sns.domain.post.Post;
+import sns.domain.post.PostService;
+import sns.domain.user.User;
+
+@RestController
+@RequiredArgsConstructor
+public class PostController {
+
+    private final PostService postService;
+
+    @PostMapping("/api/posts")
+    public ResponseEntity<PostResponse> create(
+            @AuthUser User user,
+            @RequestBody PostCreateRequest request) {
+        Post post = postService.create(request.content(), user.getId());
+        return ResponseEntity.ok(PostResponse.from(post));
+    }
+
+    @GetMapping("/api/posts")
+    public ResponseEntity<Page<PostResponse>> findAll(
+            @PageableDefault(size = 20) Pageable pageable) {
+        Page<PostResponse> posts = postService.findAll(pageable)
+                .map(PostResponse::from);
+        return ResponseEntity.ok(posts);
+    }
+
+    @GetMapping("/api/posts/{id}")
+    public ResponseEntity<PostResponse> findById(@PathVariable Long id) {
+        Post post = postService.findByIdAndIncrementViewCount(id);
+        return ResponseEntity.ok(PostResponse.from(post));
+    }
+
+    @GetMapping("/api/users/{userId}/posts")
+    public ResponseEntity<Page<PostResponse>> findByUserId(
+            @PathVariable Long userId,
+            @PageableDefault(size = 20) Pageable pageable) {
+        Page<PostResponse> posts = postService.findByUserId(userId, pageable)
+                .map(PostResponse::from);
+        return ResponseEntity.ok(posts);
+    }
+
+    @PutMapping("/api/posts/{id}")
+    public ResponseEntity<PostResponse> update(
+            @AuthUser User user,
+            @PathVariable Long id,
+            @RequestBody PostUpdateRequest request) {
+        Post post = postService.update(id, request.content(), user.getId());
+        return ResponseEntity.ok(PostResponse.from(post));
+    }
+
+    @DeleteMapping("/api/posts/{id}")
+    public ResponseEntity<Void> delete(
+            @AuthUser User user,
+            @PathVariable Long id) {
+        postService.delete(id, user.getId());
+        return ResponseEntity.noContent().build();
+    }
+
+    @PostMapping("/api/posts/{id}/view")
+    public ResponseEntity<Void> incrementView(@PathVariable Long id) {
+        postService.incrementPostView(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/sns/controller/QuoteController.java
+++ b/src/main/java/sns/controller/QuoteController.java
@@ -1,0 +1,52 @@
+package sns.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+import sns.config.AuthUser;
+import sns.controller.dto.PostResponse;
+import sns.controller.dto.QuoteCreateRequest;
+import sns.domain.post.Post;
+import sns.domain.quote.QuoteService;
+import sns.domain.user.User;
+
+@RestController
+@RequiredArgsConstructor
+public class QuoteController {
+
+    private final QuoteService quoteService;
+
+    @PostMapping("/api/posts/{postId}/quotes")
+    public ResponseEntity<PostResponse> create(
+            @AuthUser User user,
+            @PathVariable Long postId,
+            @RequestBody QuoteCreateRequest request) {
+        Post quote = quoteService.create(request.content(), user.getId(), postId);
+        return ResponseEntity.ok(PostResponse.from(quote));
+    }
+
+    @GetMapping("/api/posts/{postId}/quotes")
+    public ResponseEntity<Page<PostResponse>> findByQuoteId(
+            @PathVariable Long postId,
+            @PageableDefault(size = 20) Pageable pageable) {
+        Page<PostResponse> quotes = quoteService.findByQuoteId(postId, pageable)
+                .map(PostResponse::from);
+        return ResponseEntity.ok(quotes);
+    }
+
+    @DeleteMapping("/api/quotes/{id}")
+    public ResponseEntity<Void> delete(
+            @AuthUser User user,
+            @PathVariable Long id) {
+        quoteService.delete(id, user.getId());
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/sns/controller/ReplyController.java
+++ b/src/main/java/sns/controller/ReplyController.java
@@ -1,0 +1,52 @@
+package sns.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+import sns.config.AuthUser;
+import sns.controller.dto.PostResponse;
+import sns.controller.dto.ReplyCreateRequest;
+import sns.domain.post.Post;
+import sns.domain.reply.ReplyService;
+import sns.domain.user.User;
+
+@RestController
+@RequiredArgsConstructor
+public class ReplyController {
+
+    private final ReplyService replyService;
+
+    @PostMapping("/api/posts/{postId}/replies")
+    public ResponseEntity<PostResponse> create(
+            @AuthUser User user,
+            @PathVariable Long postId,
+            @RequestBody ReplyCreateRequest request) {
+        Post reply = replyService.create(request.content(), user.getId(), postId);
+        return ResponseEntity.ok(PostResponse.from(reply));
+    }
+
+    @GetMapping("/api/posts/{postId}/replies")
+    public ResponseEntity<Page<PostResponse>> findByParentId(
+            @PathVariable Long postId,
+            @PageableDefault(size = 20) Pageable pageable) {
+        Page<PostResponse> replies = replyService.findByParentId(postId, pageable)
+                .map(PostResponse::from);
+        return ResponseEntity.ok(replies);
+    }
+
+    @DeleteMapping("/api/replies/{id}")
+    public ResponseEntity<Void> delete(
+            @AuthUser User user,
+            @PathVariable Long id) {
+        replyService.delete(id, user.getId());
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/sns/controller/RepostController.java
+++ b/src/main/java/sns/controller/RepostController.java
@@ -1,0 +1,46 @@
+package sns.controller;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+import sns.config.AuthUser;
+import sns.controller.dto.PostResponse;
+import sns.domain.post.Post;
+import sns.domain.repost.RepostService;
+import sns.domain.user.User;
+
+@RestController
+@RequiredArgsConstructor
+public class RepostController {
+
+    private final RepostService repostService;
+
+    @PostMapping("/api/posts/{postId}/reposts")
+    public ResponseEntity<PostResponse> create(
+            @AuthUser User user,
+            @PathVariable Long postId) {
+        Post repost = repostService.create(user.getId(), postId);
+        return ResponseEntity.ok(PostResponse.from(repost));
+    }
+
+    @GetMapping("/api/posts/{postId}/reposts")
+    public ResponseEntity<List<PostResponse>> findByRepostId(@PathVariable Long postId) {
+        List<PostResponse> reposts = repostService.findByRepostId(postId).stream()
+                .map(PostResponse::from)
+                .toList();
+        return ResponseEntity.ok(reposts);
+    }
+
+    @DeleteMapping("/api/reposts/{id}")
+    public ResponseEntity<Void> delete(
+            @AuthUser User user,
+            @PathVariable Long id) {
+        repostService.delete(id, user.getId());
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/sns/controller/dto/LikeResponse.java
+++ b/src/main/java/sns/controller/dto/LikeResponse.java
@@ -1,0 +1,6 @@
+package sns.controller.dto;
+
+public record LikeResponse(
+        boolean liked
+) {
+}

--- a/src/main/java/sns/controller/dto/PostCreateRequest.java
+++ b/src/main/java/sns/controller/dto/PostCreateRequest.java
@@ -1,0 +1,6 @@
+package sns.controller.dto;
+
+public record PostCreateRequest(
+        String content
+) {
+}

--- a/src/main/java/sns/controller/dto/PostResponse.java
+++ b/src/main/java/sns/controller/dto/PostResponse.java
@@ -1,0 +1,45 @@
+package sns.controller.dto;
+
+import java.time.LocalDateTime;
+import sns.domain.post.Post;
+
+public record PostResponse(
+        Long id,
+        String content,
+        AuthorResponse author,
+        Long parentId,
+        Long quoteId,
+        Long repostId,
+        Integer repostCount,
+        Integer replyCount,
+        Integer likeCount,
+        boolean editable,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+) {
+    public static PostResponse from(Post post) {
+        return new PostResponse(
+                post.getId(),
+                post.getContent(),
+                AuthorResponse.from(post.getUser()),
+                post.getParentId(),
+                post.getQuoteId(),
+                post.getRepostId(),
+                post.getRepostCount(),
+                post.getReplyCount(),
+                post.getLikeCount(),
+                post.isEditable(),
+                post.getCreatedAt(),
+                post.getUpdatedAt()
+        );
+    }
+
+    public record AuthorResponse(
+            Long id,
+            String nickname
+    ) {
+        public static AuthorResponse from(sns.domain.user.User user) {
+            return new AuthorResponse(user.getId(), user.getNickname());
+        }
+    }
+}

--- a/src/main/java/sns/controller/dto/PostUpdateRequest.java
+++ b/src/main/java/sns/controller/dto/PostUpdateRequest.java
@@ -1,0 +1,6 @@
+package sns.controller.dto;
+
+public record PostUpdateRequest(
+        String content
+) {
+}

--- a/src/main/java/sns/controller/dto/QuoteCreateRequest.java
+++ b/src/main/java/sns/controller/dto/QuoteCreateRequest.java
@@ -1,0 +1,6 @@
+package sns.controller.dto;
+
+public record QuoteCreateRequest(
+        String content
+) {
+}

--- a/src/main/java/sns/controller/dto/ReplyCreateRequest.java
+++ b/src/main/java/sns/controller/dto/ReplyCreateRequest.java
@@ -1,0 +1,6 @@
+package sns.controller.dto;
+
+public record ReplyCreateRequest(
+        String content
+) {
+}

--- a/src/main/java/sns/domain/post/Post.java
+++ b/src/main/java/sns/domain/post/Post.java
@@ -1,0 +1,125 @@
+package sns.domain.post;
+
+import jakarta.persistence.*;
+
+import java.time.LocalDateTime;
+
+import lombok.Builder;
+import lombok.Getter;
+import sns.domain.BaseEntity;
+import sns.domain.user.User;
+
+@Entity
+@Table(name = "posts")
+@Getter
+public class Post extends BaseEntity {
+
+    private static final int EDIT_ALLOWED_HOURS = 1;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 1000)
+    private String content;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false, foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
+    private User user;
+
+    @Column(name = "parent_id")
+    private Long parentId;
+
+    @Column(name = "quote_id")
+    private Long quoteId;
+
+    @Column(name = "repost_id")
+    private Long repostId;
+
+    @Column(name = "repost_count", nullable = false)
+    private Integer repostCount = 0;
+
+    @Column(name = "reply_count", nullable = false)
+    private Integer replyCount = 0;
+
+    @Column(name = "like_count", nullable = false)
+    private Integer likeCount = 0;
+
+    @Column(name = "view_count", nullable = false)
+    private Long viewCount = 0L;
+
+
+    protected Post() {
+    }
+
+    @Builder
+    private Post(String content, User user, Long parentId, Long quoteId, Long repostId, Long viewCount) {
+        this.content = content;
+        this.user = user;
+        this.parentId = parentId;
+        this.quoteId = quoteId;
+        this.repostId = repostId;
+        this.viewCount = viewCount;
+    }
+
+    public static Post create(String content, User user) {
+        Post post = new Post();
+        post.content = content;
+        post.user = user;
+        post.repostCount = 0;
+        post.likeCount = 0;
+        post.replyCount = 0;
+        post.viewCount = 0L;
+
+        return post;
+    }
+
+    public static Post createReply(String content, User user, Long parentId) {
+        Post post = create(content, user);
+        post.parentId = parentId;
+
+        return post;
+    }
+
+    public static Post createQuote(String content, User user, Long quoteId) {
+        Post post = create(content, user);
+        post.quoteId = quoteId;
+
+        return post;
+    }
+
+    public static Post createRepost(User user, Long repostId) {
+        Post post = create("", user);
+        post.repostId = repostId;
+
+        return post;
+    }
+
+    public boolean isEditable() {
+        return getCreatedAt().plusHours(EDIT_ALLOWED_HOURS).isAfter(LocalDateTime.now());
+    }
+
+    public void updateContent(String content) {
+        this.content = content;
+    }
+
+    public void updateViewCount(Long viewCount) {
+        this.viewCount = viewCount;
+    }
+
+    public boolean isOwnedBy(Long userId) {
+        return this.user.getId().equals(userId);
+    }
+
+    public boolean isRepost() {
+        return this.repostId != null;
+    }
+
+    public boolean isReply() {
+        return this.parentId != null;
+    }
+
+    public boolean isQuote() {
+        return this.quoteId != null;
+    }
+}

--- a/src/main/java/sns/domain/post/PostException.java
+++ b/src/main/java/sns/domain/post/PostException.java
@@ -1,0 +1,24 @@
+package sns.domain.post;
+
+public class PostException extends RuntimeException {
+
+    public PostException(String message) {
+        super(message);
+    }
+
+    public static PostException notFound(Long id) {
+        return new PostException("게시글을 찾을 수 없습니다: " + id);
+    }
+
+    public static PostException notOwner() {
+        return new PostException("게시글 작성자만 수정/삭제할 수 있습니다.");
+    }
+
+    public static PostException editTimeExpired() {
+        return new PostException("게시글 수정 가능 시간(1시간)이 지났습니다.");
+    }
+
+    public static PostException cannotEditRepost() {
+        return new PostException("리포스트는 수정할 수 없습니다.");
+    }
+}

--- a/src/main/java/sns/domain/post/PostRedisRepository.java
+++ b/src/main/java/sns/domain/post/PostRedisRepository.java
@@ -1,0 +1,45 @@
+package sns.domain.post;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Repository
+@RequiredArgsConstructor
+public class PostRedisRepository {
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+    private static final String POST_VIEW_KEY_PREFIX = "post:view:";
+    private static final String DIRTY_SET_KEY = "post_view_dirty_set";
+
+    public void incrementPostView(Long postId) {
+        String key = POST_VIEW_KEY_PREFIX + postId;
+        redisTemplate.opsForValue().increment(key);
+        redisTemplate.opsForSet().add(DIRTY_SET_KEY,postId.toString());
+    }
+
+    public Long getPostView(Long postId) {
+        String key = POST_VIEW_KEY_PREFIX + postId;
+        String value = redisTemplate.opsForValue().get(key);
+        return value != null ? Long.parseLong(value) : 0L;
+    }
+
+    public Set<Long> getDirtyPostIds() {
+        Set<String> dirtyPostIdStrings = redisTemplate.opsForSet().members(DIRTY_SET_KEY);
+        if (dirtyPostIdStrings == null || dirtyPostIdStrings.isEmpty()) {
+            return Set.of();
+        }
+        return dirtyPostIdStrings.stream()
+                .map(Long::parseLong)
+                .collect(Collectors.toSet());
+    }
+
+    public void removeDirtyPostId(Long postId) {
+        redisTemplate.opsForSet().remove(DIRTY_SET_KEY, postId.toString());
+    }
+
+}

--- a/src/main/java/sns/domain/post/PostRepository.java
+++ b/src/main/java/sns/domain/post/PostRepository.java
@@ -1,0 +1,60 @@
+package sns.domain.post;
+
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface PostRepository extends JpaRepository<Post, Long> {
+
+    Optional<Post> findByIdAndDeletedAtIsNull(Long id);
+
+    Page<Post> findByUserIdAndDeletedAtIsNullOrderByCreatedAtDesc(Long userId, Pageable pageable);
+
+    Page<Post> findByDeletedAtIsNullOrderByCreatedAtDesc(Pageable pageable);
+
+    @Query("SELECT p FROM Post p WHERE p.parentId = :parentId AND p.deletedAt IS NULL ORDER BY p.createdAt DESC")
+    Page<Post> findRepliesByParentId(@Param("parentId") Long parentId, Pageable pageable);
+
+    @Query("SELECT p FROM Post p WHERE p.quoteId = :quoteId AND p.deletedAt IS NULL ORDER BY p.createdAt DESC")
+    Page<Post> findQuotesByQuoteId(@Param("quoteId") Long quoteId, Pageable pageable);
+
+    @Query("SELECT p FROM Post p WHERE p.repostId = :repostId AND p.deletedAt IS NULL ORDER BY p.createdAt DESC")
+    List<Post> findRepostsByRepostId(@Param("repostId") Long repostId);
+
+    boolean existsByUserIdAndRepostIdAndDeletedAtIsNull(Long userId, Long repostId);
+
+    boolean existsByUserIdAndQuoteIdAndDeletedAtIsNull(Long userId, Long quoteId);
+
+    @Modifying
+    @Query("UPDATE Post p SET p.replyCount = p.replyCount + 1 WHERE p.id = :id")
+    void incrementReplyCount(@Param("id") Long id);
+
+    @Modifying
+    @Query("UPDATE Post p SET p.replyCount = p.replyCount - 1 WHERE p.id = :id AND p.replyCount > 0")
+    void decrementReplyCount(@Param("id") Long id);
+
+    @Modifying
+    @Query("UPDATE Post p SET p.repostCount = p.repostCount + 1 WHERE p.id = :id")
+    void incrementRepostCount(@Param("id") Long id);
+
+    @Modifying
+    @Query("UPDATE Post p SET p.repostCount = p.repostCount - 1 WHERE p.id = :id AND p.repostCount > 0")
+    void decrementRepostCount(@Param("id") Long id);
+
+    @Modifying
+    @Query("UPDATE Post p SET p.viewCount = p.viewCount + 1 WHERE p.id = :id")
+    void incrementViewCount(@Param("id") Long id);
+
+    @Modifying
+    @Query("UPDATE Post p SET p.likeCount = p.likeCount + 1 WHERE p.id = :id")
+    void incrementLikeCount(@Param("id") Long id);
+
+    @Modifying
+    @Query("UPDATE Post p SET p.likeCount = p.likeCount - 1 WHERE p.id = :id AND p.likeCount > 0")
+    void decrementLikeCount(@Param("id") Long id);
+}

--- a/src/main/java/sns/domain/post/PostService.java
+++ b/src/main/java/sns/domain/post/PostService.java
@@ -1,0 +1,83 @@
+package sns.domain.post;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import sns.domain.user.User;
+import sns.domain.user.UserService;
+
+@Service
+@RequiredArgsConstructor
+public class PostService {
+
+    private final PostRepository postRepository;
+    private final PostRedisRepository postRedisRepository;
+    private final UserService userService;
+
+    public Post create(String content, Long userId) {
+        User user = userService.findById(userId);
+        Post post = Post.create(content, user);
+        return postRepository.save(post);
+    }
+
+    public Post findById(Long id) {
+        return postRepository.findByIdAndDeletedAtIsNull(id)
+                .orElseThrow(() -> PostException.notFound(id));
+    }
+
+    public Page<Post> findAll(Pageable pageable) {
+        return postRepository.findByDeletedAtIsNullOrderByCreatedAtDesc(pageable);
+    }
+
+    public Page<Post> findByUserId(Long userId, Pageable pageable) {
+        return postRepository.findByUserIdAndDeletedAtIsNullOrderByCreatedAtDesc(userId, pageable);
+    }
+
+    @Transactional
+    public Post findByIdAndIncrementViewCount(Long id) {
+        Post post = findById(id);
+        postRepository.incrementViewCount(id);
+        return post;
+    }
+
+    @Transactional
+    public Post update(Long postId, String content, Long userId) {
+        Post post = findById(postId);
+
+        if (!post.isOwnedBy(userId)) {
+            throw PostException.notOwner();
+        }
+
+        if (post.isRepost()) {
+            throw PostException.cannotEditRepost();
+        }
+
+        if (!post.isEditable()) {
+            throw PostException.editTimeExpired();
+        }
+
+        post.updateContent(content);
+        return post;
+    }
+
+    @Transactional
+    public void delete(Long postId, Long userId) {
+        Post post = findById(postId);
+
+        if (!post.isOwnedBy(userId)) {
+            throw PostException.notOwner();
+        }
+
+        post.delete();
+    }
+
+    public void incrementPostView(Long postId) {
+        postRedisRepository.incrementPostView(postId);
+    }
+
+    public Long getPostView(Long postId) {
+        return postRedisRepository.getPostView(postId);
+    }
+}

--- a/src/main/java/sns/domain/post/scheduler/PostViewScheduler.java
+++ b/src/main/java/sns/domain/post/scheduler/PostViewScheduler.java
@@ -1,0 +1,48 @@
+package sns.domain.post.scheduler;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import sns.domain.post.PostRedisRepository;
+import sns.domain.post.PostRepository;
+
+import java.util.Set;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PostViewScheduler {
+
+    private final PostRedisRepository postRedisRepository;
+    private final PostRepository postRepository;
+
+    @Scheduled(fixedRate = 60000)
+    @Transactional
+    public void syncPostViewsToDatabase() {
+        Set<Long> dirtyPostIds = postRedisRepository.getDirtyPostIds();
+        if (dirtyPostIds.isEmpty()) {
+            return;
+        }
+
+        log.info("Syncing post views for {} posts", dirtyPostIds.size());
+
+        dirtyPostIds.forEach(postId -> {
+            try {
+                Long postView = postRedisRepository.getPostView(postId);
+
+                postRepository.findByIdAndDeletedAtIsNull(postId).ifPresent(post -> {
+                    post.updateViewCount(postView);
+                    postRepository.save(post);
+                });
+
+
+                postRedisRepository.removeDirtyPostId(postId);
+            } catch (Exception e) {
+                log.error("Failed to sync view count for post {}", postId, e);
+            }
+        });
+    }
+
+}

--- a/src/main/java/sns/domain/quote/QuoteException.java
+++ b/src/main/java/sns/domain/quote/QuoteException.java
@@ -1,0 +1,16 @@
+package sns.domain.quote;
+
+public class QuoteException extends RuntimeException {
+
+    public QuoteException(String message) {
+        super(message);
+    }
+
+    public static QuoteException notQuote(Long id) {
+        return new QuoteException("해당 게시글은 인용이 아닙니다: " + id);
+    }
+
+    public static QuoteException alreadyQuoted() {
+        return new QuoteException("이미 인용한 게시글입니다.");
+    }
+}

--- a/src/main/java/sns/domain/quote/QuoteService.java
+++ b/src/main/java/sns/domain/quote/QuoteService.java
@@ -1,0 +1,57 @@
+package sns.domain.quote;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import sns.domain.post.Post;
+import sns.domain.post.PostException;
+import sns.domain.post.PostRepository;
+import sns.domain.user.User;
+import sns.domain.user.UserService;
+
+@Service
+@RequiredArgsConstructor
+public class QuoteService {
+
+    private final PostRepository postRepository;
+    private final UserService userService;
+
+    @Transactional
+    public Post create(String content, Long userId, Long quoteId) {
+        User user = userService.findById(userId);
+        postRepository.findByIdAndDeletedAtIsNull(quoteId)
+                .orElseThrow(() -> PostException.notFound(quoteId));
+
+        if (postRepository.existsByUserIdAndQuoteIdAndDeletedAtIsNull(userId, quoteId)) {
+            throw QuoteException.alreadyQuoted();
+        }
+
+        Post quote = Post.createQuote(content, user, quoteId);
+        postRepository.incrementRepostCount(quoteId);
+
+        return postRepository.save(quote);
+    }
+
+    public Page<Post> findByQuoteId(Long quoteId, Pageable pageable) {
+        return postRepository.findQuotesByQuoteId(quoteId, pageable);
+    }
+
+    @Transactional
+    public void delete(Long quoteId, Long userId) {
+        Post quote = postRepository.findByIdAndDeletedAtIsNull(quoteId)
+                .orElseThrow(() -> PostException.notFound(quoteId));
+
+        if (!quote.isQuote()) {
+            throw QuoteException.notQuote(quoteId);
+        }
+
+        if (!quote.isOwnedBy(userId)) {
+            throw PostException.notOwner();
+        }
+
+        postRepository.decrementRepostCount(quote.getQuoteId());
+        quote.delete();
+    }
+}

--- a/src/main/java/sns/domain/reply/ReplyException.java
+++ b/src/main/java/sns/domain/reply/ReplyException.java
@@ -1,0 +1,12 @@
+package sns.domain.reply;
+
+public class ReplyException extends RuntimeException {
+
+    public ReplyException(String message) {
+        super(message);
+    }
+
+    public static ReplyException notReply(Long id) {
+        return new ReplyException("해당 게시글은 답글이 아닙니다: " + id);
+    }
+}

--- a/src/main/java/sns/domain/reply/ReplyService.java
+++ b/src/main/java/sns/domain/reply/ReplyService.java
@@ -1,0 +1,53 @@
+package sns.domain.reply;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import sns.domain.post.Post;
+import sns.domain.post.PostException;
+import sns.domain.post.PostRepository;
+import sns.domain.user.User;
+import sns.domain.user.UserService;
+
+@Service
+@RequiredArgsConstructor
+public class ReplyService {
+
+    private final PostRepository postRepository;
+    private final UserService userService;
+
+    @Transactional
+    public Post create(String content, Long userId, Long parentId) {
+        User user = userService.findById(userId);
+        postRepository.findByIdAndDeletedAtIsNull(parentId)
+                .orElseThrow(() -> PostException.notFound(parentId));
+
+        Post reply = Post.createReply(content, user, parentId);
+        postRepository.incrementReplyCount(parentId);
+
+        return postRepository.save(reply);
+    }
+
+    public Page<Post> findByParentId(Long parentId, Pageable pageable) {
+        return postRepository.findRepliesByParentId(parentId, pageable);
+    }
+
+    @Transactional
+    public void delete(Long replyId, Long userId) {
+        Post reply = postRepository.findByIdAndDeletedAtIsNull(replyId)
+                .orElseThrow(() -> PostException.notFound(replyId));
+
+        if (!reply.isReply()) {
+            throw ReplyException.notReply(replyId);
+        }
+
+        if (!reply.isOwnedBy(userId)) {
+            throw PostException.notOwner();
+        }
+
+        postRepository.decrementReplyCount(reply.getParentId());
+        reply.delete();
+    }
+}

--- a/src/main/java/sns/domain/repost/RepostException.java
+++ b/src/main/java/sns/domain/repost/RepostException.java
@@ -1,0 +1,20 @@
+package sns.domain.repost;
+
+public class RepostException extends RuntimeException {
+
+    public RepostException(String message) {
+        super(message);
+    }
+
+    public static RepostException alreadyReposted() {
+        return new RepostException("이미 리포스트한 게시글입니다.");
+    }
+
+    public static RepostException cannotRepostOwnPost() {
+        return new RepostException("자신의 게시글은 리포스트할 수 없습니다.");
+    }
+
+    public static RepostException notRepost(Long id) {
+        return new RepostException("해당 게시글은 리포스트가 아닙니다: " + id);
+    }
+}

--- a/src/main/java/sns/domain/repost/RepostService.java
+++ b/src/main/java/sns/domain/repost/RepostService.java
@@ -1,0 +1,60 @@
+package sns.domain.repost;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import sns.domain.post.Post;
+import sns.domain.post.PostException;
+import sns.domain.post.PostRepository;
+import sns.domain.user.User;
+import sns.domain.user.UserService;
+
+@Service
+@RequiredArgsConstructor
+public class RepostService {
+
+    private final PostRepository postRepository;
+    private final UserService userService;
+
+    @Transactional
+    public Post create(Long userId, Long repostId) {
+        User user = userService.findById(userId);
+        Post originalPost = postRepository.findByIdAndDeletedAtIsNull(repostId)
+                .orElseThrow(() -> PostException.notFound(repostId));
+
+        if (originalPost.isOwnedBy(userId)) {
+            throw RepostException.cannotRepostOwnPost();
+        }
+
+        if (postRepository.existsByUserIdAndRepostIdAndDeletedAtIsNull(userId, repostId)) {
+            throw RepostException.alreadyReposted();
+        }
+
+        Post repost = Post.createRepost(user, repostId);
+        postRepository.incrementRepostCount(repostId);
+
+        return postRepository.save(repost);
+    }
+
+    public List<Post> findByRepostId(Long repostId) {
+        return postRepository.findRepostsByRepostId(repostId);
+    }
+
+    @Transactional
+    public void delete(Long repostId, Long userId) {
+        Post repost = postRepository.findByIdAndDeletedAtIsNull(repostId)
+                .orElseThrow(() -> PostException.notFound(repostId));
+
+        if (!repost.isRepost()) {
+            throw RepostException.notRepost(repostId);
+        }
+
+        if (!repost.isOwnedBy(userId)) {
+            throw PostException.notOwner();
+        }
+
+        postRepository.decrementRepostCount(repost.getRepostId());
+        repost.delete();
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -17,7 +17,7 @@ spring:
     password: sns1234
   jpa:
     hibernate:
-      ddl-auto: none
+      ddl-auto: update
     show-sql: true
     properties:
       hibernate:

--- a/src/main/resources/http/like.sh
+++ b/src/main/resources/http/like.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+BASE_URL="http://localhost:8080"
+
+echo "=== 좋아요 (postId: 1) ==="
+curl -X POST "$BASE_URL/api/posts/1/likes" \
+  -b cookies.txt
+echo -e "\n"
+
+echo "=== 좋아요 여부 확인 (postId: 1) ==="
+curl -X GET "$BASE_URL/api/posts/1/likes/me" \
+  -b cookies.txt
+echo -e "\n"
+
+echo "=== 좋아요 취소 (postId: 1) ==="
+curl -X DELETE "$BASE_URL/api/posts/1/likes" \
+  -b cookies.txt
+echo -e "\n"

--- a/src/main/resources/http/post.sh
+++ b/src/main/resources/http/post.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+BASE_URL="http://localhost:8080"
+
+echo "=== 게시글 생성 ==="
+curl -X POST "$BASE_URL/api/posts" \
+  -H "Content-Type: application/json" \
+  -b cookies.txt \
+  -d '{
+    "content": "첫 번째 게시글입니다!"
+  }'
+echo -e "\n"
+
+echo "=== 전체 게시글 조회 ==="
+curl -X GET "$BASE_URL/api/posts"
+echo -e "\n"
+
+echo "=== 게시글 상세 조회 (ID: 1) ==="
+curl -X GET "$BASE_URL/api/posts/1"
+echo -e "\n"
+
+echo "=== 게시글 수정 (ID: 1) ==="
+curl -X PUT "$BASE_URL/api/posts/1" \
+  -H "Content-Type: application/json" \
+  -b cookies.txt \
+  -d '{
+    "content": "수정된 게시글 내용입니다."
+  }'
+echo -e "\n"
+
+echo "=== 사용자별 게시글 조회 (userId: 1) ==="
+curl -X GET "$BASE_URL/api/users/1/posts"
+echo -e "\n"
+
+echo "=== 게시글 삭제 (ID: 1) ==="
+curl -X DELETE "$BASE_URL/api/posts/1" \
+  -b cookies.txt
+echo -e "\n"
+
+echo "=== 페이징 조회 (page=0, size=5) ==="
+curl -X GET "$BASE_URL/api/posts?page=0&size=5"
+echo -e "\n"

--- a/src/main/resources/http/quote.sh
+++ b/src/main/resources/http/quote.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+BASE_URL="http://localhost:8080"
+
+echo "=== 인용 작성 (postId: 1) ==="
+curl -X POST "$BASE_URL/api/posts/1/quotes" \
+  -H "Content-Type: application/json" \
+  -b cookies.txt \
+  -d '{
+    "content": "인용하면서 의견을 덧붙입니다."
+  }'
+echo -e "\n"
+
+echo "=== 인용 목록 조회 (postId: 1) ==="
+curl -X GET "$BASE_URL/api/posts/1/quotes"
+echo -e "\n"
+
+echo "=== 인용 삭제 (ID: 2) ==="
+curl -X DELETE "$BASE_URL/api/quotes/2" \
+  -b cookies.txt
+echo -e "\n"

--- a/src/main/resources/http/reply.sh
+++ b/src/main/resources/http/reply.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+BASE_URL="http://localhost:8080"
+
+echo "=== 답글 작성 (postId: 1) ==="
+curl -X POST "$BASE_URL/api/posts/1/replies" \
+  -H "Content-Type: application/json" \
+  -b cookies.txt \
+  -d '{
+    "content": "첫 번째 답글입니다!"
+  }'
+echo -e "\n"
+
+echo "=== 답글 목록 조회 (postId: 1) ==="
+curl -X GET "$BASE_URL/api/posts/1/replies"
+echo -e "\n"
+
+echo "=== 답글 삭제 (ID: 2) ==="
+curl -X DELETE "$BASE_URL/api/replies/2" \
+  -b cookies.txt
+echo -e "\n"

--- a/src/main/resources/http/repost.sh
+++ b/src/main/resources/http/repost.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+BASE_URL="http://localhost:8080"
+
+echo "=== 리포스트 (postId: 1) ==="
+curl -X POST "$BASE_URL/api/posts/1/reposts" \
+  -b cookies.txt
+echo -e "\n"
+
+echo "=== 리포스트 목록 조회 (postId: 1) ==="
+curl -X GET "$BASE_URL/api/posts/1/reposts"
+echo -e "\n"
+
+echo "=== 리포스트 삭제 (ID: 2) ==="
+curl -X DELETE "$BASE_URL/api/reposts/2" \
+  -b cookies.txt
+echo -e "\n"


### PR DESCRIPTION
## 변경사항                                                                                                                                                            
                                                                                                                                                                         
  ### 게시글,답글,인용,리포스트,좋아요 기능 구현                                                                                                                                                   
  - POST 엔티티 및 PostRepository, PostRedisRepository 추가 
  - 게시글은 조회가 많이 되므로 반정규화를 통해 count 수를 게시글 엔티티에 넣어놔야 게시글을 조회할 때마다 카운트 쿼리를 실행할 필요가 없어져 성능상 유리하다고 생각했습니다.
  - 또한 게시글과 답글, 인용, 리포스트는 모두 게시글의 성격을 띄어 게시글 엔티티에 parentId, quoteId, repostId를 넣어 null 값은 조금 많아질 수 있지만 전체적으로 통일된 형식의 게시글을 만들었습니다.                                                                                                                                                                                                                                                    
    - POST /api/posts - 게시글 생성
    - GET /api/posts - 게시글 조회                                                                                                                         
    - POST /api/posts/{postId}/replies - 게시글 답글 생성
    - GET /api/posts/{postId}/replies - 게시글 답글 조회
    - POST /api/posts/{postId}/quotes- 게시글 인용 생성  
    - GET /api/posts/{postId}/quotes- 게시글 인용 조회               
    - POST /api/posts/{postId}/reposts - 게시글 리포스트 생성                                                                                                                                              
    - GET /api/posts/{postId}/reposts - 게시글 리포스트 조회        
    - POST /api/posts/{postId}/view - 게시글 레디스 조회수 증가                                                                                                                                               
                                                                                                              
                                                                                 

### 게시글 조회수 설계 (읽기/쓰기 부하문제)
조회수를 RDB에 직접 업데이트하면 모든 읽기가 쓰기를 유발합니다.
- 예를 들어서 초당 1000번 조회를 한다고 치면 초당 1000번의 업데이트 쿼리를 날리기에 디스크 I/O 병목과 트랜잭션 경합을 유발합니다.

**그래서 Redis 캐싱 + 배치 동기화를 선택하였습니다.**
하지만 Redis 캐싱 + 배치 동기화만 선택할 경우 문제점이 있습니다.
어떤 게시글이 바뀌었는지 모릅니다

- 예를 들어 게시글 수가 100만이면 매 분마다 Redis GET 100만 번 + UPDATE 100만 번 조회수 증가가 없는 게시글도 매번 비용 발생합니다.

Redis key scan은 키 전체를 훑는 작업으로 Redis CPU 부하 + latency 증가합니다.

**그래서 조회수 추적하는 Dirty Set 패턴을 사용하였습니다.** 
게시글 Redis에 게시글 조회수를 증가할때 게시글ID를 Set 자료구조에 추가해놓는것입니다.
그리고 나서 1분마다 Dirty Set에서 조회수가 바뀐 게시글 아이디 목록을 먼저 가져와 게시글의 조회수를 Redis에서 읽어서 데이터베이스에 저장합니다.
처리된 게시글은 Dirty Set에서 제거하면 됩니다.

하지만 Dirty Set에 있는 postId를 삭제할 때 동시에 조회수가 발생한 postId를 삭제할 수도 있고 그게 마지막으로 게시글을 조회한거였다면 해당 조회수는 누락될 수 있습니다.

이처럼 약간의 오차와 유실이 발생할 수 있지만 **약간의 오차는 허용**하도록 설계하였습니다.
