### PR TITLE
feat: Pre-signed URL 기반 미디어 업로드 서비스 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	implementation 'org.springframework.session:spring-session-data-redis'
 	implementation 'org.springframework:spring-aspects'
+	implementation("software.amazon.awssdk:s3:2.29.26")
 
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,24 @@ services:
     volumes:
       - postgres-data:/var/lib/postgresql/data
 
+  rustfs:
+    image: rustfs/rustfs:1.0.0-alpha.72
+    container_name: springboot-sns-rustfs
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+    environment:
+      RUSTFS_ADDRESS: 0.0.0.0:9000
+      RUSTFS_CONSOLE_ADDRESS: 0.0.0.0:9001
+      RUSTFS_CONSOLE_ENABLE: "true"
+      RUSTFS_ACCESS_KEY: rustfsadmin
+      RUSTFS_SECRET_KEY: rustfsadmin
+    volumes:
+      - rustfs-data:/data
+      - rustfs-logs:/logs
+
 volumes:
   redis-data:
   postgres-data:
+  rustfs-data:
+  rustfs-logs:

--- a/src/main/java/sns/SnsApplication.java
+++ b/src/main/java/sns/SnsApplication.java
@@ -2,9 +2,11 @@ package sns;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
+@ConfigurationPropertiesScan
 @SpringBootApplication
 @EnableJpaAuditing
 @EnableScheduling

--- a/src/main/java/sns/config/GlobalExceptionHandler.java
+++ b/src/main/java/sns/config/GlobalExceptionHandler.java
@@ -7,6 +7,7 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import sns.domain.follow.FollowException;
+import sns.domain.media.MediaException;
 import sns.domain.post.PostException;
 import sns.domain.quote.QuoteException;
 import sns.domain.reply.ReplyException;
@@ -53,6 +54,13 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(RepostException.class)
     public ResponseEntity<ErrorResponse> handleRepostException(RepostException e) {
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(new ErrorResponse(e.getMessage()));
+    }
+
+    @ExceptionHandler(MediaException.class)
+    public ResponseEntity<ErrorResponse> handleMediaException(MediaException e) {
         return ResponseEntity
                 .status(HttpStatus.BAD_REQUEST)
                 .body(new ErrorResponse(e.getMessage()));

--- a/src/main/java/sns/config/s3/RustFsProperties.java
+++ b/src/main/java/sns/config/s3/RustFsProperties.java
@@ -1,0 +1,14 @@
+package sns.config.s3;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "rustfs")
+public record RustFsProperties(
+        String endpoint,
+        String accessKey,
+        String secretKey,
+        String bucket,
+        String region,
+        Long presignedUrlExpirationSeconds
+) {
+}

--- a/src/main/java/sns/config/s3/S3Config.java
+++ b/src/main/java/sns/config/s3/S3Config.java
@@ -1,0 +1,52 @@
+package sns.config.s3;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3Configuration;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+
+import java.net.URI;
+
+@Configuration
+@RequiredArgsConstructor
+public class S3Config {
+
+    private final RustFsProperties rustFsProperties;
+
+    @Bean
+    public S3Client s3Client() {
+        return S3Client.builder()
+                .endpointOverride(URI.create(rustFsProperties.endpoint()))
+                .region(Region.of(rustFsProperties.region()))
+                .credentialsProvider(StaticCredentialsProvider.create(
+                        AwsBasicCredentials.create(
+                                rustFsProperties.accessKey(),
+                                rustFsProperties.secretKey()
+                        )
+                ))
+                .forcePathStyle(true)
+                .build();
+    }
+
+    @Bean
+    public S3Presigner s3Presigner() {
+        return S3Presigner.builder()
+                .endpointOverride(URI.create(rustFsProperties.endpoint()))
+                .region(Region.of(rustFsProperties.region()))
+                .credentialsProvider(StaticCredentialsProvider.create(
+                        AwsBasicCredentials.create(
+                                rustFsProperties.accessKey(),
+                                rustFsProperties.secretKey()
+                        )
+                ))
+                .serviceConfiguration(S3Configuration.builder()
+                        .pathStyleAccessEnabled(true)
+                        .build())
+                .build();
+    }
+}

--- a/src/main/java/sns/controller/MediaController.java
+++ b/src/main/java/sns/controller/MediaController.java
@@ -1,0 +1,70 @@
+package sns.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import sns.config.AuthUser;
+import sns.controller.dto.MediaUploadedRequest;
+import sns.controller.media.MediaInitRequest;
+import sns.controller.media.MediaInitResponse;
+import sns.controller.media.MediaResponse;
+import sns.controller.media.PresignedUrlResponse;
+import sns.domain.media.Media;
+import sns.domain.media.MediaService;
+import sns.domain.media.PresignedUrl;
+import sns.domain.user.User;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+public class MediaController {
+
+    private final MediaService mediaService;
+
+    @PostMapping("/api/media/init")
+    public ResponseEntity<MediaInitResponse> create(
+            @AuthUser User user,
+            @RequestBody MediaInitRequest request) {
+        PresignedUrl result = mediaService.initMedia(request.mediaType(), request.fileSize(), user);
+        return ResponseEntity.ok(MediaInitResponse.from(result));
+    }
+
+    @GetMapping("/api/media/{id}/presigned-url")
+    public PresignedUrlResponse getPresignedUrl(@PathVariable Long id) {
+        Media media = mediaService.getMediaById(id);
+        String presignedUrl = mediaService.getPresignedUrl(media);
+
+        return new PresignedUrlResponse(presignedUrl, MediaResponse.from(media));
+    }
+
+    @PostMapping("/api/media/uploaded")
+    public MediaResponse mediaUploaded(
+            @RequestBody MediaUploadedRequest request,
+            @AuthUser User user
+    ) {
+        Media media = mediaService.mediaUploaded(request.mediaId(), request.parts(), user);
+        return MediaResponse.from(media);
+    }
+
+    @GetMapping("/api/media/{id}")
+    public MediaResponse getMediaById(@PathVariable Long id) {
+        Media media = mediaService.getMediaById(id);
+        return MediaResponse.from(media);
+    }
+
+    @GetMapping("/api/users/{userId}/media")
+    public List<MediaResponse> getMediaByUserId(@PathVariable Long userId) {
+        return mediaService.getMediaByUserId(userId).stream()
+                .map(MediaResponse::from)
+                .toList();
+    }
+
+    @DeleteMapping("/api/media/{id}")
+    public void deleteMedia(
+            @PathVariable Long id,
+            @AuthUser User user
+    ) {
+        mediaService.deleteMedia(id, user);
+    }
+}

--- a/src/main/java/sns/controller/dto/MediaUploadedRequest.java
+++ b/src/main/java/sns/controller/dto/MediaUploadedRequest.java
@@ -1,0 +1,11 @@
+package sns.controller.dto;
+
+import sns.domain.media.MultipartUploaded;
+
+import java.util.List;
+
+public record MediaUploadedRequest(
+        Long mediaId,
+        List<MultipartUploaded> parts
+) {
+}

--- a/src/main/java/sns/controller/media/MediaCreateRequest.java
+++ b/src/main/java/sns/controller/media/MediaCreateRequest.java
@@ -1,0 +1,13 @@
+package sns.controller.media;
+
+import sns.domain.media.MediaType;
+
+import java.util.Map;
+
+public record MediaCreateRequest(
+        MediaType mediaType,
+        String path,
+        Long postId,
+        Map<String, Object> attributes
+) {
+}

--- a/src/main/java/sns/controller/media/MediaInitRequest.java
+++ b/src/main/java/sns/controller/media/MediaInitRequest.java
@@ -1,0 +1,9 @@
+package sns.controller.media;
+
+import sns.domain.media.MediaType;
+
+public record MediaInitRequest(
+        MediaType mediaType,
+        Long fileSize
+) {
+}

--- a/src/main/java/sns/controller/media/MediaInitResponse.java
+++ b/src/main/java/sns/controller/media/MediaInitResponse.java
@@ -1,0 +1,34 @@
+package sns.controller.media;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import sns.domain.media.*;
+
+public record MediaInitResponse(
+        Long id,
+        MediaType mediaType,
+        String path,
+        MediaStatus status,
+        Long userId,
+        String presignedUrl,
+        String uploadId,
+        List<PresignedUrlPart> presignedUrlParts,
+        LocalDateTime createdAt
+) {
+    public static MediaInitResponse from(PresignedUrl presignedUrl) {
+        Media media = presignedUrl.media();
+
+        return new MediaInitResponse(
+                media.getId(),
+                media.getMediaType(),
+                media.getPath(),
+                media.getStatus(),
+                media.getUserId(),
+                presignedUrl.presignedUrl(),
+                presignedUrl.uploadId(),
+                presignedUrl.presignedUrlParts(),
+                media.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/sns/controller/media/MediaResponse.java
+++ b/src/main/java/sns/controller/media/MediaResponse.java
@@ -1,0 +1,32 @@
+package sns.controller.media;
+
+import sns.domain.media.Media;
+import sns.domain.media.MediaStatus;
+import sns.domain.media.MediaType;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+
+public record MediaResponse(
+        Long id,
+        MediaType mediaType,
+        String path,
+        MediaStatus status,
+        Long userId,
+        Long fileSize,
+        Map<String, Object> attributes,
+        LocalDateTime createdAt
+) {
+    public static MediaResponse from(Media media) {
+        return new MediaResponse(
+                media.getId(),
+                media.getMediaType(),
+                media.getPath(),
+                media.getStatus(),
+                media.getUserId(),
+                media.getFileSize(),
+                media.getAttributes(),
+                media.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/sns/controller/media/MediaUpdateAttributesRequest.java
+++ b/src/main/java/sns/controller/media/MediaUpdateAttributesRequest.java
@@ -1,0 +1,8 @@
+package sns.controller.media;
+
+import java.util.Map;
+
+public record MediaUpdateAttributesRequest(
+        Map<String, Object> attributes
+) {
+}

--- a/src/main/java/sns/controller/media/MediaUpdateRequest.java
+++ b/src/main/java/sns/controller/media/MediaUpdateRequest.java
@@ -1,0 +1,12 @@
+package sns.controller.media;
+
+import sns.domain.media.MediaStatus;
+
+import java.util.Map;
+
+public record MediaUpdateRequest(
+        String path,
+        MediaStatus status,
+        Map<String, Object> attributes
+) {
+}

--- a/src/main/java/sns/controller/media/PresignedUrlResponse.java
+++ b/src/main/java/sns/controller/media/PresignedUrlResponse.java
@@ -1,0 +1,7 @@
+package sns.controller.media;
+
+public record PresignedUrlResponse(
+        String presignedUrl,
+        MediaResponse media
+) {
+}

--- a/src/main/java/sns/domain/media/Media.java
+++ b/src/main/java/sns/domain/media/Media.java
@@ -1,0 +1,82 @@
+package sns.domain.media;
+
+import jakarta.persistence.*;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.Builder;
+import lombok.Getter;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+import sns.domain.BaseEntity;
+
+@Entity
+@Table(name = "media")
+@Getter
+public class Media extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "media_type", nullable = false, length = 20)
+    private MediaType mediaType;
+
+    @Column(name = "path", length = 2000)
+    private String path;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 20)
+    private MediaStatus status;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "upload_id", length = 500)
+    private String uploadId;
+
+    @Column
+    private Long fileSize;
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "attributes", columnDefinition = "jsonb")
+    private Map<String, Object> attributes;
+
+    protected Media() {
+    }
+
+    @Builder
+    private Media(MediaType mediaType, String path, MediaStatus status, Long userId, String uploadId, Map<String, Object> attributes) {
+        this.mediaType = mediaType;
+        this.path = path;
+        this.status = status;
+        this.userId = userId;
+        this.uploadId = uploadId;
+        this.attributes = attributes != null ? attributes : new HashMap<>();
+    }
+
+    public static Media create(MediaType mediaType,String path,Long userId,Long fileSize) {
+        Media media = new Media();
+        media.mediaType = mediaType;
+        media.path = path;
+        media.status = MediaStatus.INIT;
+        media.userId = userId;
+        media.fileSize = fileSize;
+        return media;
+    }
+
+    public static Media create(MediaType mediaType, String path, Long userId, Long fileSize, String uploadId) {
+        Media media = create(mediaType, path, userId, fileSize);
+        media.uploadId = uploadId;
+        return media;
+    }
+
+    public void updateStatus(MediaStatus status) {
+        this.status = status;
+    }
+
+
+    public void updateAttributes(Map<String, Object> attributes) {
+        this.attributes = attributes != null ? attributes : new HashMap<>();
+    }
+}

--- a/src/main/java/sns/domain/media/MediaException.java
+++ b/src/main/java/sns/domain/media/MediaException.java
@@ -1,0 +1,28 @@
+package sns.domain.media;
+
+public class MediaException extends RuntimeException {
+
+    public MediaException(String message) {
+        super(message);
+    }
+
+    public static MediaException notFound(Long id) {
+        return new MediaException("미디어를 찾을 수 없습니다: " + id);
+    }
+
+    public static MediaException notFoundByUploadId(String uploadId) {
+        return new MediaException("업로드 ID로 미디어를 찾을 수 없습니다: " + uploadId);
+    }
+
+    public static MediaException notOwner() {
+        return new MediaException("미디어 소유자만 수정/삭제할 수 있습니다.");
+    }
+
+    public static MediaException invalidStatus(MediaStatus current, MediaStatus expected) {
+        return new MediaException("잘못된 상태입니다. 현재: " + current + ", 예상: " + expected);
+    }
+
+    public static MediaException alreadyCompleted() {
+        return new MediaException("이미 완료된 미디어입니다.");
+    }
+}

--- a/src/main/java/sns/domain/media/MediaRepository.java
+++ b/src/main/java/sns/domain/media/MediaRepository.java
@@ -1,0 +1,19 @@
+package sns.domain.media;
+
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface MediaRepository extends JpaRepository<Media, Long> {
+
+    Optional<Media> findByIdAndDeletedAtIsNull(Long id);
+
+    List<Media> findByUserIdAndDeletedAtIsNullOrderByCreatedAtDesc(Long userId);
+
+    @Query(value = "SELECT * FROM media WHERE attributes -> 'parts' @> :partNumberJson\\:\\:jsonb AND deleted_at IS NULL ORDER BY created_at DESC", nativeQuery = true)
+    List<Media> findByPartNumber(@Param("partNumberJson") String partNumberJson);
+}

--- a/src/main/java/sns/domain/media/MediaService.java
+++ b/src/main/java/sns/domain/media/MediaService.java
@@ -1,0 +1,151 @@
+package sns.domain.media;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.util.CollectionUtils;
+import sns.config.s3.RustFsProperties;
+import sns.domain.user.User;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedGetObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
+
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class MediaService {
+
+    private static final long MULTIPART_THRESHOLD = 8 * 1024 * 1024; // 8MB = 8,388,608
+
+    private final MediaRepository mediaRepository;
+    private final MultipartService multipartService;
+    private final S3Presigner s3Presigner;
+    private final RustFsProperties rustFsProperties;
+
+    public PresignedUrl initMedia(MediaType mediaType, Long fileSize, User user) {
+        return initMedia(mediaType, fileSize, user, "posts");
+    }
+
+    public PresignedUrl initMedia(MediaType mediaType, Long fileSize, User user, String subPath) {
+        String filename = UUID.randomUUID() + mediaType.fileExtension();
+        String path = String.format("users/%s/%s/%s", user.getId(), subPath, filename);
+
+        if (fileSize != null && fileSize > MULTIPART_THRESHOLD) {
+            return initMultipartUpload(user, path, mediaType, fileSize);
+        }
+
+
+        return initSingleUpload(user, path, mediaType, fileSize);
+    }
+
+    public Media mediaUploaded(Long mediaId, List<MultipartUploaded> parts, User user) {
+        Media media = getMediaById(mediaId);
+
+        if (!media.getUserId().equals(user.getId())) {
+            throw new IllegalArgumentException("You are not authorized to update this media");
+        }
+
+        if (media.getStatus() != MediaStatus.INIT) {
+            throw new IllegalArgumentException("Media is not in INIT status");
+        }
+
+        if (media.getUploadId() != null && !CollectionUtils.isEmpty(parts)) {
+            multipartService.completeMultipartUpload(media.getPath(), media.getUploadId(), parts);
+
+            Map<String, Object> attributes = new HashMap<>();
+            attributes.put("parts", parts);
+            media.updateAttributes(attributes);
+        }
+
+        media.updateStatus(MediaStatus.UPLOADED);
+
+        return mediaRepository.save(media);
+    }
+
+    public Media getMediaById(Long id) {
+        return mediaRepository.findByIdAndDeletedAtIsNull(id)
+                .orElseThrow(() -> new IllegalArgumentException("Media not found: " + id));
+    }
+
+    public List<Media> getMediaByUserId(Long userId) {
+        return mediaRepository.findByUserIdAndDeletedAtIsNullOrderByCreatedAtDesc(userId);
+    }
+
+    public void deleteMedia(Long id, User user) {
+        Media media = getMediaById(id);
+
+        if (!media.getUserId().equals(user.getId())) {
+            throw new IllegalArgumentException("You are not authorized to delete this media");
+        }
+
+        media.delete();
+        mediaRepository.save(media);
+    }
+
+    public String getPresignedUrl(Long id) {
+        return getPresignedUrl(getMediaById(id));
+    }
+
+    public String getPresignedUrl(Media media) {
+        GetObjectRequest getObjectRequest = GetObjectRequest.builder()
+                .bucket(rustFsProperties.bucket())
+                .key(media.getPath())
+                .build();
+
+        GetObjectPresignRequest presignRequest = GetObjectPresignRequest.builder()
+                .signatureDuration(Duration.ofSeconds(rustFsProperties.presignedUrlExpirationSeconds()))
+                .getObjectRequest(getObjectRequest)
+                .build();
+
+        PresignedGetObjectRequest presignedRequest = s3Presigner.presignGetObject(presignRequest);
+        return presignedRequest.url().toString();
+    }
+
+    private PresignedUrl initSingleUpload(User user, String path, MediaType mediaType, Long fileSize) {
+        log.info("MediaService use SingleUpload : user={}", user.getId());
+
+        PutObjectRequest putObjectRequest = PutObjectRequest.builder()
+                .bucket(rustFsProperties.bucket())
+                .key(path)
+                .contentType(mediaType.contentType())
+                .build();
+
+        PutObjectPresignRequest presignRequest = PutObjectPresignRequest.builder()
+                .signatureDuration(Duration.ofSeconds(rustFsProperties.presignedUrlExpirationSeconds()))
+                .putObjectRequest(putObjectRequest)
+                .build();
+
+        PresignedPutObjectRequest presignedRequest = s3Presigner.presignPutObject(presignRequest);
+        String presignedUrl = presignedRequest.url().toString();
+
+        Media media = Media.create(mediaType, path, user.getId(), fileSize);
+        media = mediaRepository.save(media);
+
+        return PresignedUrl.forSingleUpload(media, presignedUrl);
+    }
+
+    private PresignedUrl initMultipartUpload(User user, String path, MediaType mediaType, long fileSize) {
+        log.info("MediaService use MultipartUpload : user={}", user.getId());
+
+        MultipartUploadInfo uploadInfo = multipartService.initMultipartUpload(
+                path,
+                mediaType.contentType(),
+                fileSize
+        );
+
+        Media media = Media.create(mediaType, path, user.getId(), fileSize, uploadInfo.uploadId());
+        media = mediaRepository.save(media);
+
+        return PresignedUrl.forMultipartUpload(media, uploadInfo.uploadId(), uploadInfo.presignedUrlParts());
+    }
+}

--- a/src/main/java/sns/domain/media/MediaStatus.java
+++ b/src/main/java/sns/domain/media/MediaStatus.java
@@ -1,0 +1,8 @@
+package sns.domain.media;
+
+public enum MediaStatus {
+    INIT,
+    UPLOADED,
+    COMPLETED,
+    FAILED
+}

--- a/src/main/java/sns/domain/media/MediaType.java
+++ b/src/main/java/sns/domain/media/MediaType.java
@@ -1,0 +1,20 @@
+package sns.domain.media;
+
+public enum MediaType {
+    IMAGE,
+    VIDEO;
+
+    public String fileExtension(){
+        return switch (this) {
+            case IMAGE -> ".jpg";
+            case VIDEO -> ".mp4";
+        };
+    }
+
+    public String contentType(){
+        return switch (this) {
+            case IMAGE -> "image/jpeg";
+            case VIDEO -> "video/mp4";
+        };
+    }
+}

--- a/src/main/java/sns/domain/media/MultipartService.java
+++ b/src/main/java/sns/domain/media/MultipartService.java
@@ -1,0 +1,82 @@
+package sns.domain.media;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import sns.config.s3.RustFsProperties;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.*;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedUploadPartRequest;
+import software.amazon.awssdk.services.s3.presigner.model.UploadPartPresignRequest;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class MultipartService {
+
+    private static final long PART_SIZE = 8 * 1024 * 1024; // 8MB
+
+    private final S3Client s3Client;
+    private final S3Presigner s3Presigner;
+    private final RustFsProperties rustFsProperties;
+
+    public MultipartUploadInfo initMultipartUpload(String path, String contentType, long fileSize) {
+        CreateMultipartUploadRequest createRequest = CreateMultipartUploadRequest.builder()
+                .bucket(rustFsProperties.bucket())
+                .key(path)
+                .contentType(contentType)
+                .build();
+
+        CreateMultipartUploadResponse createResponse = s3Client.createMultipartUpload(createRequest);
+        String uploadId = createResponse.uploadId();
+
+        int numberOfParts = (int) Math.ceil((double) fileSize / PART_SIZE);
+
+        List<PresignedUrlPart> presignedUrlParts = new ArrayList<>();
+        for (int partNumber = 1; partNumber <= numberOfParts; partNumber++) {
+            UploadPartRequest uploadPartRequest = UploadPartRequest.builder()
+                    .bucket(rustFsProperties.bucket())
+                    .key(path)
+                    .uploadId(uploadId)
+                    .partNumber(partNumber)
+                    .build();
+
+            UploadPartPresignRequest presignRequest = UploadPartPresignRequest.builder()
+                    .signatureDuration(Duration.ofSeconds(rustFsProperties.presignedUrlExpirationSeconds()))
+                    .uploadPartRequest(uploadPartRequest)
+                    .build();
+
+            PresignedUploadPartRequest presignedRequest = s3Presigner.presignUploadPart(presignRequest);
+            String presignedUrl = presignedRequest.url().toString();
+
+            presignedUrlParts.add(new PresignedUrlPart(partNumber, presignedUrl));
+        }
+
+        return new MultipartUploadInfo(uploadId, presignedUrlParts);
+    }
+
+    public void completeMultipartUpload(String path, String uploadId, List<MultipartUploaded> parts) {
+        List<CompletedPart> s3Parts = parts.stream()
+                .map(part -> CompletedPart.builder()
+                        .partNumber(part.partNumber())
+                        .eTag(part.eTag())
+                        .build())
+                .toList();
+
+        CompletedMultipartUpload completedMultipartUpload = CompletedMultipartUpload.builder()
+                .parts(s3Parts)
+                .build();
+
+        CompleteMultipartUploadRequest completeRequest = CompleteMultipartUploadRequest.builder()
+                .bucket(rustFsProperties.bucket())
+                .key(path)
+                .uploadId(uploadId)
+                .multipartUpload(completedMultipartUpload)
+                .build();
+
+        s3Client.completeMultipartUpload(completeRequest);
+    }
+}

--- a/src/main/java/sns/domain/media/MultipartUploadInfo.java
+++ b/src/main/java/sns/domain/media/MultipartUploadInfo.java
@@ -1,0 +1,9 @@
+package sns.domain.media;
+
+import java.util.List;
+
+public record MultipartUploadInfo(
+        String uploadId,
+        List<PresignedUrlPart> presignedUrlParts
+) {
+}

--- a/src/main/java/sns/domain/media/MultipartUploaded.java
+++ b/src/main/java/sns/domain/media/MultipartUploaded.java
@@ -1,0 +1,7 @@
+package sns.domain.media;
+
+public record MultipartUploaded(
+        int partNumber,
+        String eTag
+) {
+}

--- a/src/main/java/sns/domain/media/PresignedUrl.java
+++ b/src/main/java/sns/domain/media/PresignedUrl.java
@@ -1,0 +1,19 @@
+package sns.domain.media;
+
+import java.util.List;
+
+public record PresignedUrl(
+        Media media,
+        String presignedUrl,
+        String uploadId,                         // 멀티 파트 필드
+        List<PresignedUrlPart> presignedUrlParts // 멀티 파트 필드
+) {
+
+    public static PresignedUrl forSingleUpload(Media media, String presignedUrl) {
+        return new PresignedUrl(media, presignedUrl, null, null);
+    }
+
+    public static PresignedUrl forMultipartUpload(Media media, String uploadId, List<PresignedUrlPart> presignedUrlParts) {
+        return new PresignedUrl(media, null, uploadId, presignedUrlParts);
+    }
+}

--- a/src/main/java/sns/domain/media/PresignedUrlPart.java
+++ b/src/main/java/sns/domain/media/PresignedUrlPart.java
@@ -1,0 +1,7 @@
+package sns.domain.media;
+
+public record PresignedUrlPart(
+        int partNumber,
+        String presignedUrl
+) {
+}

--- a/src/main/java/sns/domain/post/Post.java
+++ b/src/main/java/sns/domain/post/Post.java
@@ -3,6 +3,7 @@ package sns.domain.post;
 import jakarta.persistence.*;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 import lombok.Builder;
 import lombok.Getter;
@@ -47,6 +48,9 @@ public class Post extends BaseEntity {
 
     @Column(name = "view_count", nullable = false)
     private Long viewCount = 0L;
+
+    @Column(name = "media_ids", columnDefinition = "bigint[]")
+    private List<Long> mediaIds;
 
 
     protected Post() {

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -22,3 +22,10 @@ spring:
     properties:
       hibernate:
         format_sql: true
+rustfs:
+  endpoint: http://localhost:9000
+  access-key: rustfsadmin
+  secret-key: rustfsadmin
+  bucket: media
+  region: ap-northeast-2
+  presigned-url-expiration-seconds: 3600

--- a/src/main/resources/http/media.sh
+++ b/src/main/resources/http/media.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+
+BASE_URL="http://localhost:8080"
+
+echo "=== 미디어 생성 (IMAGE) ==="
+curl -X POST "$BASE_URL/api/media" \
+  -H "Content-Type: application/json" \
+  -b cookies.txt \
+  -d '{
+    "mediaType": "IMAGE"
+  }'
+echo -e "\n"
+
+echo "=== 미디어 생성 (VIDEO) ==="
+curl -X POST "$BASE_URL/api/media" \
+  -H "Content-Type: application/json" \
+  -b cookies.txt \
+  -d '{
+    "mediaType": "VIDEO"
+  }'
+echo -e "\n"
+
+echo "=== 미디어 상세 조회 (ID: 1) ==="
+curl -X GET "$BASE_URL/api/media/1"
+echo -e "\n"
+
+echo "=== 내 미디어 목록 조회 ==="
+curl -X GET "$BASE_URL/api/media" \
+  -b cookies.txt
+echo -e "\n"
+
+echo "=== 사용자별 미디어 조회 (userId: 1) ==="
+curl -X GET "$BASE_URL/api/users/1/media"
+echo -e "\n"
+
+echo "=== 상태별 미디어 조회 (INIT) ==="
+curl -X GET "$BASE_URL/api/media/status/INIT" \
+  -b cookies.txt
+echo -e "\n"
+
+echo "=== 업로드 초기화 (ID: 1) ==="
+curl -X PUT "$BASE_URL/api/media/1/init-upload" \
+  -H "Content-Type: application/json" \
+  -b cookies.txt \
+  -d '{
+    "uploadId": "upload-12345",
+    "path": "/media/images/2024/01/image-001.jpg"
+  }'
+echo -e "\n"
+
+echo "=== 업로드 완료 표시 (ID: 1) ==="
+curl -X PUT "$BASE_URL/api/media/1/uploaded" \
+  -b cookies.txt
+echo -e "\n"
+
+echo "=== 처리 완료 표시 (ID: 1) ==="
+curl -X PUT "$BASE_URL/api/media/1/completed" \
+  -b cookies.txt
+echo -e "\n"
+
+echo "=== 처리 실패 표시 (ID: 2) ==="
+curl -X PUT "$BASE_URL/api/media/2/failed" \
+  -b cookies.txt
+echo -e "\n"
+
+echo "=== 메타데이터 업데이트 (ID: 1) ==="
+curl -X PUT "$BASE_URL/api/media/1/attributes" \
+  -H "Content-Type: application/json" \
+  -b cookies.txt \
+  -d '{
+    "attributes": {
+      "width": 1920,
+      "height": 1080,
+      "format": "jpeg",
+      "size": 1048576
+    }
+  }'
+echo -e "\n"
+
+echo "=== 미디어 삭제 (ID: 1) ==="
+curl -X DELETE "$BASE_URL/api/media/1" \
+  -b cookies.txt
+echo -e "\n"
+
+echo "=== 페이징 조회 (page=0, size=10) ==="
+curl -X GET "$BASE_URL/api/media?page=0&size=10" \
+  -b cookies.txt
+echo -e "\n"


### PR DESCRIPTION
 ## Summary                                                                                                                                                             
  - S3 호환 오브젝트 스토리지 연동 및 Pre-signed URL 기반 미디어 업로드 구현                                                                                             
  - 파일 크기에 따라 싱글/멀티파트 업로드 자동 분기 (기준: 8MB)                                                                                                          
  - 프론트엔드 미디어 업로드 훅 및 API 연동                                                                                                                              
                                                                                                                                                                         
  ## 주요 변경사항                                                                                                                                                       
                                                                                                                                                                         
  ### Backend                                                                                                                                                            
  **새로운 파일**                                                                                                                                                        
  - `domain/media/Media.java` - 미디어 엔티티                                                                                                                            
  - `domain/media/MediaType.java` - IMAGE, VIDEO enum                                                                                                                    
  - `domain/media/MediaStatus.java` - INIT, UPLOADED, COMPLETED, FAILED enum                                                                                             
  - `domain/media/MediaRepository.java` - JPA 리포지토리                                                                                                                 
  - `domain/media/MediaService.java` - 미디어 비즈니스 로직                                                                                                              
  - `domain/media/MediaException.java` - 도메인 예외                                                                                                                     
  - `domain/media/MultipartService.java` - 멀티파트 업로드 처리                                                                                                          
  - `domain/media/PresignedUrl.java` - Pre-signed URL 응답 VO                                                                                                            
  - `domain/media/PresignedUrlPart.java` - 멀티파트 URL 파트 정보                                                                                                        
  - `domain/media/MultipartUploaded.java` - 업로드 완료 파트 정보                                                                                                        
  - `domain/media/MultipartUploadInfo.java` - 멀티파트 초기화 정보                                                                                                       
  - `controller/MediaController.java` - REST API 컨트롤러                                                                                                                
  - `controller/media/*.java` - 요청/응답 DTO                                                                                                                            
  - `config/s3/S3Config.java` - S3 클라이언트 설정                                                                                                                       
  - `config/s3/RustFsProperties.java` - S3 설정 프로퍼티                                                                                                                 
                                                                                                                                                                         
  ### Frontend                                                                                                                                                           
  **수정된 파일**                                                                                                                                                        
  - `lib/api/media.ts` - API 경로 수정 (/api/v1 → /api)                                                                                                                  
  - `lib/types/media.ts` - 백엔드 응답에 맞게 타입 수정                                                                                                                  
  - `components/media-gallery.tsx` - GIF 타입 처리 제거                                                                                                                  
                                                                                                                                                                         
  ## 업로드 흐름                                                                                                                                                         
                                                                                                                                                                         
  [싱글 업로드 - 8MB 미만]                                                                                                                                               
  Client → Backend: POST /api/media/init                                                                                                                                 
  Backend → Client: presignedUrl                                                                                                                                         
  Client → S3: PUT 파일                                                                                                                                                  
  Client → Backend: POST /api/media/uploaded                                                                                                                             
                                                                                                                                                                         
  [멀티파트 업로드 - 8MB 이상]                                                                                                                                           
  Client → Backend: POST /api/media/init                                                                                                                                 
  Backend → S3: CreateMultipartUpload                                                                                                                                    
  Backend → Client: uploadId + presignedUrlParts[]                                                                                                                       
  Client: file.slice()로 청크 분할                                                                                                                                       
  Client → S3: 각 파트 PUT (ETag 수집)                                                                                                                                   
  Client → Backend: POST /api/media/uploaded (parts[])                                                                                                                   
  Backend → S3: CompleteMultipartUpload                     